### PR TITLE
Add Wikivibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ AI assistants for database queries, schema design, and data analysis.
 - [LeetCode](https://leetcode.com/) - Interview prep (some AI features).
 - [CodeAcademy](https://www.codecademy.com/) - Interactive learning.
 - [Brilliant](https://brilliant.org/) - CS fundamentals with AI.
+- [Wikivibe](https://wikivibe.ru/en/) - Practical knowledge base for AI-assisted development with guides, a glossary, jobs, and a public MCP endpoint.
 
 ## Productivity Tools
 


### PR DESCRIPTION
Adds Wikivibe as a practical AI-assisted development knowledge base with guides, a glossary, jobs, and a public MCP endpoint.

Checked: link opens successfully at https://wikivibe.ru/en/.

Disclosure: I am affiliated with Wikivibe.