### PR TITLE
Add Playcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ Tools that can autonomously build apps, implement features, or complete coding t
   - Deployment automation
   - Iterative refinement
 
+- [Playcode](https://playcode.io/ai-website-builder) - AI website and app builder.
+  - Natural language to hosted sites and web apps
+  - Visual editing and AI chat iteration
+  - One-click publishing
+  - Custom domains and Playcode Cloud hosting
+
 - [Devin](https://www.cognition.ai/devin) - AI software engineer.
   - Autonomous coding agent
   - Can complete entire tasks


### PR DESCRIPTION
Adds Playcode to AI Agents & Autonomous Coding.

Why it fits: Playcode turns natural-language prompts into hosted sites and web apps, then supports visual editing, AI chat iteration, one-click publishing, and custom domains. That matches the app-builder tools already listed here, including Bolt.new and Lovable.

Changed only the README entry.
