### PR TITLE
Add UIZZE UI finish-gate workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ The future of coding is here - AI assistants that understand context, generate c
   - Figma integration
   - High-fidelity designs
 
+- [UIZZE](https://uizze.com) - UI reference catalogue and finish-gate skill for coding agents.
+  - Search 800,000+ real web and iOS screens for interface evidence
+  - Free anti-UI-slop skill for Codex, Claude Code, Cursor, and Copilot
+  - Design contract and finish gate for generic layouts and missing states
+  - Optional MCP integration for automated search and audits
+
 - [Butterfish](https://butterfi.sh/) - Shell copilot.
   - AI assistance in terminal
   - Context-aware suggestions


### PR DESCRIPTION
## What changed

Adds UIZZE to **Specialized Tools** as a UI-reference and finish-gate workflow for coding agents.

## Why it belongs here

- It is directly usable by Codex, Claude Code, Cursor, Copilot, and other Agent Skills-compatible tools.
- The free workflow searches a public catalogue of 800,000+ web and iOS screens, writes a design contract, and checks generic layouts and missing interface states before shipping.
- The entry follows the repository's existing one-tool format and links to the official HTTPS site.

## Validation

- Confirmed `https://uizze.com` and `https://uizze.com/docs` return HTTP 200.
- Checked the README for an existing UIZZE entry; none exists.
- `git diff --check` passes.
- `awesome-lint` currently reports its repository-detection rule locally; the submitted six-line entry introduces no structural or ordering change outside the existing Specialized Tools list.

## Affiliation

I am contributing on behalf of Aislon, the organization behind UIZZE.
