### PR TITLE
PinZheng(docs): add codex-profiles workflow utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ The future of coding is here - AI assistants that understand context, generate c
 
 ### CLI Tools
 
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - Manage named Codex CLI profiles with separate local `CODEX_HOME` state.
+  - Run Codex CLI and one-shot commands in a selected profile
+  - Supports per-profile login, status, and diagnostics
+  - Can launch matching isolated ChatGPT Desktop windows on macOS
+
 - [vnsh](https://github.com/raullenchai/vnsh) - Ephemeral encrypted file sharing for AI.
   - Pipe logs, diffs, files to secure URLs
   - Client-side AES-256 encryption


### PR DESCRIPTION
## Summary

- Adds `codex-profiles` to the **CLI Tools** section.
- Notes named `CODEX_HOME` profiles, profile-scoped CLI commands, and macOS Desktop support.

## Why it is useful

It helps developers keep separate Codex CLI local state for different workflows while using a single dependency-free command-line tool.

## Validation

- `git diff --check`

## Disclosure

I am the creator/maintainer of `codex-profiles`.

Closes #6.
