### PR TITLE
Add cursor-bridge: Claude Code on your Cursor subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ The future of coding is here - AI assistants that understand context, generate c
   - Multi-file editing
   - Undo/redo support
 
+- [cursor-bridge](https://github.com/hkc5/cursor-bridge) - Claude Code that runs on your Cursor subscription. One Rust binary, zero config.
+
 - [ChatGPT CLI](https://github.com/j178/chatgpt) - ChatGPT in the terminal.
   - Interactive chat
   - Code generation


### PR DESCRIPTION
cursor-bridge is a Rust binary that lets Claude Code run on Cursor's backend instead of Anthropic's API. If you already have a Cursor subscription, this makes Claude Code effectively free (Cursor's auto model is unlimited with subscription).

Features:
- Single Rust binary (~780KB), zero dependencies, zero config
- Tool execution (shell, file write, reads) works out of the box
- Agent runs in isolated temp dir — cannot touch your project files
- No daemon, no background process, no env vars to configure
- macOS + Linux

https://github.com/hkc5/cursor-bridge