### PR TITLE
Add Kolega Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,11 @@ Tools that can autonomously build apps, implement features, or complete coding t
   - Persists and recovers sessions across restarts
   - Source-available for non-commercial use; commercial use requires permission
 
-- [Kolega Code](https://github.com/kolega-ai/kolega-code) - Open-source terminal coding agent where the model writes its own multi-agent workflows.
+- [Kolega Code](https://github.com/kolega-ai/kolega-code) - Source-available terminal coding agent where the model writes its own multi-agent workflows.
   - Gigacode: model-authored orchestration programs with parallel phases and pipelines
   - 15+ model providers, MCP support, and a Textual TUI
   - Local-first sessions with journaled resume
+  - BSL 1.1 licensed; production use allowed except competing hosted offerings
 
 ## Browser Automation & UI Agents
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ Tools that can autonomously build apps, implement features, or complete coding t
   - Persists and recovers sessions across restarts
   - Source-available for non-commercial use; commercial use requires permission
 
+- [Kolega Code](https://github.com/kolega-ai/kolega-code) - Open-source terminal coding agent where the model writes its own multi-agent workflows.
+  - Gigacode: model-authored orchestration programs with parallel phases and pipelines
+  - 15+ model providers, MCP support, and a Textual TUI
+  - Local-first sessions with journaled resume
+
 ## Browser Automation & UI Agents
 
 AI agents that can interact with websites, automate UI tasks, and perform web-based actions.


### PR DESCRIPTION
# Add Kolega Code

Adds Kolega Code to the AI Agents & Autonomous Coding section, at the end of the section.

It is an open-source terminal coding agent where the model writes its own multi-agent workflows. For repo-wide tasks the model authors a Python orchestration program (Gigacode) that runs parallel phases and pipelines under concurrency and budget caps. Runs 15+ providers, supports MCP servers, keeps state local, and is fully documented.
