### PR TITLE
Add d1v deployment workflow to Infrastructure & DevOps AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,11 @@ AI tools for infrastructure as code, cloud management, and DevOps automation.
   - Infrastructure recommendations
   - Cost analysis
 
+- [d1v](https://github.com/d1vai/d1v-cli) - CLI deployment workflow for AI-built web projects.
+  - Claude Code and Codex Skill support
+  - Waits for a verified Preview deployment state
+  - Requires interactive confirmation before Production release
+
 ## Database & SQL AI Tools
 
 AI assistants for database queries, schema design, and data analysis.


### PR DESCRIPTION
## Summary

Adds [d1v](https://github.com/d1vai/d1v-cli) to **Infrastructure & DevOps AI**.

## Why it is useful

d1v is a CLI deployment workflow for AI-built web projects. Its official Skill supports Claude Code and Codex, waits for a verified Preview deployment state, and requires an interactive terminal plus explicit confirmation before a Production release.

## Validation

- Verified the canonical public repository, MIT license, documentation, and official `SKILL.md` path.
- Confirmed the project is not already listed.
- `git diff --check` passed.

## Disclosure

I am affiliated with d1v, the maintainer of the linked project. This PR changes only the target list entry; no target-project commands were run.
