### PR TITLE
Add Sillage

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,12 @@ The future of coding is here - AI assistants that understand context, generate c
   - Rename, move, and safe-delete refactors with cross-file references
   - MIT licensed
 
+- [Sillage](https://github.com/MarlBurroW/sillage) - Self-hosted, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine.
+  - Sessions that outlive the client, with full-text search across every conversation
+  - IDE panel (file explorer, editor, diffs, terminal) and a board agents read through its own MCP server
+  - Installable PWA with push; single Docker container
+  - MIT licensed
+
 ## AI Agents & Autonomous Coding
 
 Tools that can autonomously build apps, implement features, or complete coding tasks with minimal human intervention.


### PR DESCRIPTION
Adds Sillage to Specialized Tools.

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (the official agent harnesses, without a terminal). It offers sessions that outlive the client, full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

Repo: https://github.com/MarlBurroW/sillage

Entry follows the section format (bullet + nested feature bullets), is actively maintained and documented, and is not a duplicate.

Disclosure: I am the author of Sillage.