### PR TITLE
Fix daily update footer and reuse one PR branch

### DIFF
--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -33,7 +33,7 @@ jobs:
         DATE=$(date +'%B %d, %Y')
         # Add or update the last updated line
         if grep -q "Last updated:" README.md; then
-          sed -i "s/Last updated: .*/Last updated: $DATE/" README.md
+          sed -i "s/^\*Last updated: .*\*$/*Last updated: $DATE*/" README.md
         else
           echo -e "\n---\n\n*Last updated: $DATE*" >> README.md
         fi
@@ -62,5 +62,5 @@ jobs:
           - ✅ Checked for broken links
           
           Please review and merge if everything looks good!
-        branch: daily-update-${{ github.run_number }}
+        branch: daily-update
         delete-branch: true


### PR DESCRIPTION
## Summary

Every automated daily PR since the refresh (#19, #20, #22, #24) turned the footer into `*Last updated: September 06, 2026` with no closing asterisk, which breaks the italics. The sed pattern in the workflow replaced to end of line and ate the trailing `*`.

- Anchor the sed on both asterisks so the footer keeps its formatting. Tested against the current footer.
- Use a fixed `daily-update` branch so `create-pull-request` updates one open PR instead of opening a new one per day.

The four broken daily PRs are closed; the next scheduled run will open a correct one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)